### PR TITLE
Add PDF Editor with clear options and bulk processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@vercel/analytics": "^1.4.1",
+        "jszip": "^3.10.1",
         "lucide-react": "^0.471.0",
         "next": "15.1.4",
         "pdf-lib": "^1.17.1",
@@ -1835,6 +1836,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3259,6 +3266,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -3285,6 +3298,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -3846,6 +3865,18 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3888,6 +3919,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -4662,6 +4702,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -4742,6 +4788,27 @@
       "dependencies": {
         "pify": "^2.3.0"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -4896,6 +4963,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -4998,6 +5071,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.33.5",
@@ -5183,6 +5262,15 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-width": {
@@ -5795,7 +5883,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^1.4.1",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.471.0",
     "next": "15.1.4",
     "pdf-lib": "^1.17.1",

--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -2,11 +2,11 @@
 
 import React, {ChangeEvent, useState} from 'react';
 import CustomerInfoForm from './CustomerInfoForm';
-import FileUploadBox from './FileUploadBox';
 import JobTypeSelector from './JobTypeSelector';
 import PdfPopulateButton from '@/app/new/PdfPopulateButton';
 import {handleGenerateJob} from "@/app/new/GenerateJob";
 import {FacilityOwnerInfo, RepresentativeInfo} from "@/components/types/customer";
+import PdfUploadBox from "@/components/pdf-upload-box";
 
 
 export default function NewRFJob() {
@@ -104,7 +104,7 @@ export default function NewRFJob() {
                                 onRepresentativeChange={handleInfoChange(setRepresentativeInfo)}
                             />
 
-                            <FileUploadBox pdfs={pdfs} onUpdateFiles={setPdfs}/>
+                            <PdfUploadBox pdfs={pdfs} onUpdateFiles={setPdfs}/>
 
                             <div className="card-actions justify-end">
                                 <button type="submit" className="btn btn-primary">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,27 +1,40 @@
 'use client'
 
 export default function Home() {
-  return (
-      <main className="min-h-screen bg-base-300 flex items-center justify-center">
-        <div className="card w-96 bg-base-100 shadow-xl">
-          <div className="card-body">
-            <h1 className="card-title text-2xl font-bold mb-6">ReportFlow Jobs</h1>
-            <div className="space-y-4">
-              <button
-                  className="btn btn-primary w-full"
-                  onClick={() => window.location.href = '/new'}
-              >
-                Create New RF Job
-              </button>
-              <button
-                  className="btn btn-secondary w-full"
-                  onClick={() => window.location.href = '/edit'}
-              >
-                Edit Existing RF Job
-              </button>
+    return (
+        <main className="min-h-screen bg-base-300 flex flex-col items-center justify-center space-y-6">
+            <div className="card w-96 bg-base-100 shadow-xl">
+                <div className="card-body">
+                    <h1 className="card-title text-2xl font-bold mb-6">ReportFlow Tools</h1>
+                    <div className="space-y-4">
+                        <button
+                            className="btn btn-primary w-full"
+                            onClick={() => window.location.href = '/new'}
+                        >
+                            Create New RF Job
+                        </button>
+                        <button
+                            className="btn btn-secondary w-full"
+                            onClick={() => window.location.href = '/edit'}
+                        >
+                            Edit Existing RF Job
+                        </button>
+                    </div>
+                </div>
             </div>
-          </div>
-        </div>
-      </main>
-  );
+            <div className="card w-96 bg-base-100 shadow-xl">
+                <div className="card-body">
+                    <h1 className="card-title text-2xl font-bold mb-6">PDF Tools</h1>
+                    <div className="space-y-4">
+                        <button
+                            className="btn btn-primary w-full"
+                            onClick={() => window.location.href = '/pdf-editor'}
+                        >
+                            Edit PDF
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </main>
+    );
 }

--- a/src/app/pdf-editor/GeneratePdfs.tsx
+++ b/src/app/pdf-editor/GeneratePdfs.tsx
@@ -29,11 +29,29 @@ const generateSinglePdf = async (clearOptions: ClearOptions, pdf: File) => {
         link.click();
         URL.revokeObjectURL(url);
     } catch (e) {
-        console.error(e)
+        console.error(e);
         throw e;
     }
 }
 
 const generateMultiplePdfs = async (clearOptions: ClearOptions, pdfs: File[]) => {
+    try {
+        const zipBlob = await PDFProcessor.clearMultiplePDFs(pdfs, {
+            KeepInfo: clearOptions.keepGenericInfo,
+            KeepComments: clearOptions.keepComments,
+            KeepInitialTestData: clearOptions.keepInitialTestData,
+            KeepRepairData: clearOptions.keepRepairData,
+            KeepFinalTestData: clearOptions.keepFinalTestData,
+        })
 
+        const url = URL.createObjectURL(zipBlob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'processed_pdfs.zip'
+        link.click();
+        URL.revokeObjectURL(url);
+    } catch (e) {
+        console.error(e);
+        throw e;
+    }
 }

--- a/src/app/pdf-editor/GeneratePdfs.tsx
+++ b/src/app/pdf-editor/GeneratePdfs.tsx
@@ -1,5 +1,5 @@
 import {ClearOptions} from "@/app/pdf-editor/PdfClearOptions";
-import {PDFProcessor} from "@/components/util/pdfProcessor";
+import {PDFProcessor, PDFProcessorOptions} from "@/components/util/pdfProcessor";
 
 export const handleGeneratePdfs = async (
     clearOptions: ClearOptions,
@@ -14,13 +14,7 @@ export const handleGeneratePdfs = async (
 
 const generateSinglePdf = async (clearOptions: ClearOptions, pdf: File) => {
     try {
-        const modifiedPdfBlob = await PDFProcessor.clearPDF(pdf, {
-            KeepInfo: clearOptions.keepGenericInfo,
-            KeepComments: clearOptions.keepComments,
-            KeepInitialTestData: clearOptions.keepInitialTestData,
-            KeepRepairData: clearOptions.keepRepairData,
-            KeepFinalTestData: clearOptions.keepFinalTestData,
-        })
+        const modifiedPdfBlob = await PDFProcessor.clearPDF(pdf, getProcessorOptions(clearOptions))
 
         const url = URL.createObjectURL(modifiedPdfBlob.blob);
         const link = document.createElement('a');
@@ -36,13 +30,7 @@ const generateSinglePdf = async (clearOptions: ClearOptions, pdf: File) => {
 
 const generateMultiplePdfs = async (clearOptions: ClearOptions, pdfs: File[]) => {
     try {
-        const zipBlob = await PDFProcessor.clearMultiplePDFs(pdfs, {
-            KeepInfo: clearOptions.keepGenericInfo,
-            KeepComments: clearOptions.keepComments,
-            KeepInitialTestData: clearOptions.keepInitialTestData,
-            KeepRepairData: clearOptions.keepRepairData,
-            KeepFinalTestData: clearOptions.keepFinalTestData,
-        })
+        const zipBlob = await PDFProcessor.clearMultiplePDFs(pdfs, getProcessorOptions(clearOptions))
 
         const url = URL.createObjectURL(zipBlob);
         const link = document.createElement('a');
@@ -53,5 +41,15 @@ const generateMultiplePdfs = async (clearOptions: ClearOptions, pdfs: File[]) =>
     } catch (e) {
         console.error(e);
         throw e;
+    }
+}
+
+const getProcessorOptions = (clearOptions: ClearOptions): PDFProcessorOptions => {
+    return {
+        KeepInfo: clearOptions.keepGenericInfo,
+        KeepComments: clearOptions.keepComments,
+        KeepInitialTestData: clearOptions.keepTestData ? clearOptions.keepInitialTestData : false,
+        KeepRepairData: clearOptions.keepTestData ? clearOptions.keepRepairData : false,
+        KeepFinalTestData: clearOptions.keepTestData ? clearOptions.keepFinalTestData : false,
     }
 }

--- a/src/app/pdf-editor/GeneratePdfs.tsx
+++ b/src/app/pdf-editor/GeneratePdfs.tsx
@@ -1,0 +1,39 @@
+import {ClearOptions} from "@/app/pdf-editor/PdfClearOptions";
+import {PDFProcessor} from "@/components/util/pdfProcessor";
+
+export const handleGeneratePdfs = async (
+    clearOptions: ClearOptions,
+    pdfs: File[]
+) => {
+    if (pdfs.length === 1) {
+        await generateSinglePdf(clearOptions, pdfs[0])
+    } else {
+        await generateMultiplePdfs(clearOptions, pdfs)
+    }
+}
+
+const generateSinglePdf = async (clearOptions: ClearOptions, pdf: File) => {
+    try {
+        const modifiedPdfBlob = await PDFProcessor.clearPDF(pdf, {
+            KeepInfo: clearOptions.keepGenericInfo,
+            KeepComments: clearOptions.keepComments,
+            KeepInitialTestData: clearOptions.keepInitialTestData,
+            KeepRepairData: clearOptions.keepRepairData,
+            KeepFinalTestData: clearOptions.keepFinalTestData,
+        })
+
+        const url = URL.createObjectURL(modifiedPdfBlob.blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `${modifiedPdfBlob.serialNo}.pdf`;
+        link.click();
+        URL.revokeObjectURL(url);
+    } catch (e) {
+        console.error(e)
+        throw e;
+    }
+}
+
+const generateMultiplePdfs = async (clearOptions: ClearOptions, pdfs: File[]) => {
+
+}

--- a/src/app/pdf-editor/PdfClearOptions.tsx
+++ b/src/app/pdf-editor/PdfClearOptions.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-interface ClearOptions {
+export interface ClearOptions {
     keepGenericInfo: boolean;
     keepTestData: boolean;
     keepComments: boolean;
-    keepInitialTestData?: boolean;
-    keepRepairData?: boolean;
-    keepFinalTestData?: boolean;
+    keepInitialTestData: boolean;
+    keepRepairData: boolean;
+    keepFinalTestData: boolean;
 }
 
 interface PdfClearOptionsProps {

--- a/src/app/pdf-editor/PdfClearOptions.tsx
+++ b/src/app/pdf-editor/PdfClearOptions.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+interface ClearOptions {
+    keepGenericInfo: boolean;
+    keepTestData: boolean;
+    keepComments: boolean;
+}
+
+interface PdfClearOptionsProps {
+    clearOptions: ClearOptions;
+    onOptionChange: (option: keyof ClearOptions) => void;
+}
+
+export default function PdfClearOptions({clearOptions, onOptionChange}: PdfClearOptionsProps) {
+    return (
+        <>
+            <label className="label">
+                <span className="text-xl font-semibold">PDF Clear Actions</span>
+            </label>
+
+            <div className="flex flex-row gap-4 mb-4">
+                <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                        type="checkbox"
+                        className="checkbox checkbox-primary"
+                        checked={clearOptions.keepGenericInfo}
+                        onChange={() => onOptionChange('keepGenericInfo')}
+                    />
+                    <span className="label-text">Keep Generic Info</span>
+                </label>
+
+                <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                        type="checkbox"
+                        className="checkbox checkbox-primary"
+                        checked={clearOptions.keepTestData}
+                        onChange={() => onOptionChange('keepTestData')}
+                    />
+                    <span className="label-text">Keep Test Data</span>
+                </label>
+
+                <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                        type="checkbox"
+                        className="checkbox checkbox-primary"
+                        checked={clearOptions.keepComments}
+                        onChange={() => onOptionChange('keepComments')}
+                    />
+                    <span className="label-text">Keep Comments</span>
+                </label>
+            </div>
+        </>
+    );
+}

--- a/src/app/pdf-editor/PdfClearOptions.tsx
+++ b/src/app/pdf-editor/PdfClearOptions.tsx
@@ -4,6 +4,9 @@ interface ClearOptions {
     keepGenericInfo: boolean;
     keepTestData: boolean;
     keepComments: boolean;
+    keepInitialTestData?: boolean;
+    keepRepairData?: boolean;
+    keepFinalTestData?: boolean;
 }
 
 interface PdfClearOptionsProps {
@@ -18,36 +21,72 @@ export default function PdfClearOptions({clearOptions, onOptionChange}: PdfClear
                 <span className="text-xl font-semibold">PDF Clear Actions</span>
             </label>
 
-            <div className="flex flex-row gap-4 mb-4">
-                <label className="flex items-center gap-2 cursor-pointer">
-                    <input
-                        type="checkbox"
-                        className="checkbox checkbox-primary"
-                        checked={clearOptions.keepGenericInfo}
-                        onChange={() => onOptionChange('keepGenericInfo')}
-                    />
-                    <span className="label-text">Keep Generic Info</span>
-                </label>
+            <div className="flex flex-col gap-4 mb-4">
+                <div className="flex flex-row gap-4">
+                    <label className="flex items-center gap-2 cursor-pointer">
+                        <input
+                            type="checkbox"
+                            className="checkbox checkbox-primary"
+                            checked={clearOptions.keepGenericInfo}
+                            onChange={() => onOptionChange('keepGenericInfo')}
+                        />
+                        <span className="label-text">Keep Generic Info</span>
+                    </label>
 
-                <label className="flex items-center gap-2 cursor-pointer">
-                    <input
-                        type="checkbox"
-                        className="checkbox checkbox-primary"
-                        checked={clearOptions.keepTestData}
-                        onChange={() => onOptionChange('keepTestData')}
-                    />
-                    <span className="label-text">Keep Test Data</span>
-                </label>
+                    <label className="flex items-center gap-2 cursor-pointer">
+                        <input
+                            type="checkbox"
+                            className="checkbox checkbox-primary"
+                            checked={clearOptions.keepTestData}
+                            onChange={() => onOptionChange('keepTestData')}
+                        />
+                        <span className="label-text">Keep Test Data</span>
+                    </label>
 
-                <label className="flex items-center gap-2 cursor-pointer">
-                    <input
-                        type="checkbox"
-                        className="checkbox checkbox-primary"
-                        checked={clearOptions.keepComments}
-                        onChange={() => onOptionChange('keepComments')}
-                    />
-                    <span className="label-text">Keep Comments</span>
-                </label>
+                    <label className="flex items-center gap-2 cursor-pointer">
+                        <input
+                            type="checkbox"
+                            className="checkbox checkbox-primary"
+                            checked={clearOptions.keepComments}
+                            onChange={() => onOptionChange('keepComments')}
+                        />
+                        <span className="label-text">Keep Comments</span>
+                    </label>
+                </div>
+
+                {clearOptions.keepTestData && (
+                    <div className="flex flex-row gap-4 ml-8">
+                        <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="checkbox"
+                                className="checkbox checkbox-secondary"
+                                checked={clearOptions.keepInitialTestData}
+                                onChange={() => onOptionChange('keepInitialTestData')}
+                            />
+                            <span className="label-text">Keep Initial Test Data</span>
+                        </label>
+
+                        <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="checkbox"
+                                className="checkbox checkbox-secondary"
+                                checked={clearOptions.keepRepairData}
+                                onChange={() => onOptionChange('keepRepairData')}
+                            />
+                            <span className="label-text">Keep Repair Data</span>
+                        </label>
+
+                        <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="checkbox"
+                                className="checkbox checkbox-secondary"
+                                checked={clearOptions.keepFinalTestData}
+                                onChange={() => onOptionChange('keepFinalTestData')}
+                            />
+                            <span className="label-text">Keep Final Test Data</span>
+                        </label>
+                    </div>
+                )}
             </div>
         </>
     );

--- a/src/app/pdf-editor/page.tsx
+++ b/src/app/pdf-editor/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export default function PdfEditor() {
+    return (
+        <main className="min-h-screen bg-base-300 flex items-center justify-center">
+            <div className="card w-96 bg-base-100 shadow-xl">
+                <div className="card-body">
+                    <p className="text-center text-gray-500">Page in progress...</p>
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/src/app/pdf-editor/page.tsx
+++ b/src/app/pdf-editor/page.tsx
@@ -3,6 +3,7 @@
 import PdfUploadBox from "@/components/pdf-upload-box";
 import React, {useState} from "react";
 import PdfClearOptions from "@/app/pdf-editor/PdfClearOptions";
+import {handleGeneratePdfs} from "@/app/pdf-editor/GeneratePdfs";
 
 export default function PdfEditor() {
     const [pdfs, setPdfs] = useState<File[]>([]);
@@ -32,6 +33,11 @@ export default function PdfEditor() {
         }));
     };
 
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        await handleGeneratePdfs(clearOptions, pdfs)
+    }
+
     return (
         <main className="min-h-screen bg-base-300 p-8">
             <div className="max-w-2xl mx-auto">
@@ -43,18 +49,21 @@ export default function PdfEditor() {
                             </div>
                         </div>
 
-                        <PdfClearOptions
-                            clearOptions={clearOptions}
-                            onOptionChange={handleClearOptionsChange}
-                        />
+                        <form onSubmit={handleSubmit} className="space-y-4">
 
-                        <PdfUploadBox pdfs={pdfs} onUpdateFiles={setPdfs}/>
+                            <PdfClearOptions
+                                clearOptions={clearOptions}
+                                onOptionChange={handleClearOptionsChange}
+                            />
 
-                        <div className="card-actions justify-end">
-                            <button type="submit" className="btn btn-primary">
-                                Download Updated PDF(s)
-                            </button>
-                        </div>
+                            <PdfUploadBox pdfs={pdfs} onUpdateFiles={setPdfs}/>
+
+                            <div className="card-actions justify-end">
+                                <button type="submit" className="btn btn-primary">
+                                    Download Updated PDF(s)
+                                </button>
+                            </div>
+                        </form>
                     </div>
                 </div>
             </div>

--- a/src/app/pdf-editor/page.tsx
+++ b/src/app/pdf-editor/page.tsx
@@ -9,10 +9,23 @@ export default function PdfEditor() {
     const [clearOptions, setClearOptions] = useState({
         keepGenericInfo: false,
         keepTestData: false,
-        keepComments: false
+        keepComments: false,
+        keepInitialTestData: false,
+        keepRepairData: false,
+        keepFinalTestData: false,
     });
 
-    const handleCheckboxChange = (option: keyof typeof clearOptions) => {
+    const handleClearOptionsChange = (option: keyof typeof clearOptions) => {
+        if (option === 'keepTestData' && !clearOptions.keepTestData) {
+            // If keepTestData is being unchecked, reset all  sub options
+            setClearOptions(prev => ({
+                ...prev,
+                keepInitialTestData: true,
+                keepRepairData: false,
+                keepFinalTestData: false
+            }));
+        }
+
         setClearOptions(prev => ({
             ...prev,
             [option]: !prev[option]
@@ -32,7 +45,7 @@ export default function PdfEditor() {
 
                         <PdfClearOptions
                             clearOptions={clearOptions}
-                            onOptionChange={handleCheckboxChange}
+                            onOptionChange={handleClearOptionsChange}
                         />
 
                         <PdfUploadBox pdfs={pdfs} onUpdateFiles={setPdfs}/>

--- a/src/app/pdf-editor/page.tsx
+++ b/src/app/pdf-editor/page.tsx
@@ -1,11 +1,32 @@
 'use client'
 
+import PdfUploadBox from "@/components/pdf-upload-box";
+import React, {useState} from "react";
+
 export default function PdfEditor() {
+    const [pdfs, setPdfs] = useState<File[]>([]);
+
     return (
-        <main className="min-h-screen bg-base-300 flex items-center justify-center">
-            <div className="card w-96 bg-base-100 shadow-xl">
-                <div className="card-body">
-                    <p className="text-center text-gray-500">Page in progress...</p>
+        <main className="min-h-screen bg-base-300 p-8">
+            <div className="max-w-2xl mx-auto">
+                <div className="card bg-base-100 shadow-xl">
+                    <div className="card-body">
+
+                        <div className="flex justify-between items-center">
+                            <div className="flex justify-between items-center mb-6 w-full">
+                                <h1 className="card-title text-2xl font-bold text-left">PDF Editor</h1>
+                            </div>
+                        </div>
+
+
+                        <PdfUploadBox pdfs={pdfs} onUpdateFiles={setPdfs}/>
+
+                        <div className="card-actions justify-end">
+                            <button type="submit" className="btn btn-primary">
+                                Download Updated PDF(s)
+                            </button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </main>

--- a/src/app/pdf-editor/page.tsx
+++ b/src/app/pdf-editor/page.tsx
@@ -2,22 +2,38 @@
 
 import PdfUploadBox from "@/components/pdf-upload-box";
 import React, {useState} from "react";
+import PdfClearOptions from "@/app/pdf-editor/PdfClearOptions";
 
 export default function PdfEditor() {
     const [pdfs, setPdfs] = useState<File[]>([]);
+    const [clearOptions, setClearOptions] = useState({
+        keepGenericInfo: false,
+        keepTestData: false,
+        keepComments: false
+    });
+
+    const handleCheckboxChange = (option: keyof typeof clearOptions) => {
+        setClearOptions(prev => ({
+            ...prev,
+            [option]: !prev[option]
+        }));
+    };
 
     return (
         <main className="min-h-screen bg-base-300 p-8">
             <div className="max-w-2xl mx-auto">
                 <div className="card bg-base-100 shadow-xl">
                     <div className="card-body">
-
                         <div className="flex justify-between items-center">
                             <div className="flex justify-between items-center mb-6 w-full">
                                 <h1 className="card-title text-2xl font-bold text-left">PDF Editor</h1>
                             </div>
                         </div>
 
+                        <PdfClearOptions
+                            clearOptions={clearOptions}
+                            onOptionChange={handleCheckboxChange}
+                        />
 
                         <PdfUploadBox pdfs={pdfs} onUpdateFiles={setPdfs}/>
 

--- a/src/components/pdf-upload-box/index.tsx
+++ b/src/components/pdf-upload-box/index.tsx
@@ -1,7 +1,7 @@
-﻿import { Upload, Trash2 } from "lucide-react";
-import React, { useState } from "react";
+import {Trash2, Upload} from "lucide-react";
+import React, {useState} from "react";
 
-export default function FileUploadBox({
+export default function PdfUploadBox({
                                          pdfs,
                                          onUpdateFiles,
                                      }: {
@@ -60,7 +60,7 @@ export default function FileUploadBox({
                 onDragLeave={handleDragLeave}
                 onDrop={handleDrop}
             >
-                <Upload className="mx-auto h-12 w-12 text-gray-400" />
+                <Upload className="mx-auto h-12 w-12 text-gray-400"/>
                 <div>
                     <label className="btn btn-primary">
                         Upload PDFs
@@ -97,7 +97,7 @@ export default function FileUploadBox({
                                         className="btn btn-error btn-sm"
                                         onClick={() => handleFileRemove(index)}
                                     >
-                                        <Trash2 className="w-4 h-4" />
+                                        <Trash2 className="w-4 h-4"/>
                                     </button>
                                 </li>
                             ))}

--- a/src/components/util/pdfProcessor.ts
+++ b/src/components/util/pdfProcessor.ts
@@ -130,4 +130,5 @@ class PDFProcessor {
     }
 }
 
-export {PDFProcessor, PDFFieldManager, type PDFProcessorOptions};
+export {PDFProcessor, PDFFieldManager};
+export type {PDFProcessorOptions};

--- a/src/components/util/pdfProcessor.ts
+++ b/src/components/util/pdfProcessor.ts
@@ -1,0 +1,122 @@
+import {PDFCheckBox, PDFDocument, PDFDropdown, PDFField, PDFOptionList, PDFRadioGroup, PDFTextField} from 'pdf-lib';
+
+interface PDFProcessorOptions {
+    KeepInfo?: boolean;
+    KeepComments?: boolean;
+    KeepInitialTestData?: boolean;
+    KeepRepairData?: boolean;
+    KeepFinalTestData?: boolean;
+}
+
+type FieldName = string;
+
+class PDFFieldManager {
+    static getInfoFieldNames(): FieldName[] {
+        return [
+            'WaterPurveyor',
+            // Facility Owner
+            'FacilityOwner', 'Address', 'Email', 'Contact', 'Phone',
+            // Representative Owner
+            'OwnerRep', 'RepAddress', 'PersontoContact', 'Phone-0',
+            // Location Info
+            'AssemblyAddress', 'On Site Location of Assembly', 'PrimaryBusinessService',
+            // Installation Info
+            'InstallationIs', 'ProtectionType', 'ServiceType',
+            // Device Info 1
+            'SerialNo', 'WaterMeterNo', 'Size', 'ModelNo', 'SOVComment',
+            // Device Info 2
+            'BFType', 'Manufacturer', 'SOVList'
+        ];
+    }
+
+    static getInitialFieldNames(): FieldName[] {
+        return [
+            'DateFailed', 'InitialTester', 'InitialTesterNo', 'InitialTestKitSerial',
+            'LinePressure', 'InitialCT1', 'InitialCT2', 'InitialPSIRV', 'InitialAirInlet', 'InitialCk1PVB',
+            'InitialCTBox', 'InitialCT1Leaked', 'InitialCT2Box', 'InitialCT2Leaked',
+            'InitialRVDidNotOpen', 'InitialAirInletLeaked', 'InitialCkPVBLDidNotOpen', 'InitialCkPVBLeaked'
+        ];
+    }
+
+    static getRepairsFieldNames(): FieldName[] {
+        return [
+            'RepairedTester', 'RepairedTesterNo', 'DateRepaired', 'RepairedTestKitSerial',
+            // Check Valve
+            'Ck1Cleaned', 'Ck1CheckDisc', 'Ck1DiscHolder', 'Ck1Spring', 'Ck1Guide', 'Ck1Seat', 'Ck1Other',
+            'Ck2Cleaned', 'Ck2CheckDisc', 'Ck2DiscHolder', 'Ck2Spring', 'Ck2Guide', 'Ck2Seat', 'Ck2Other',
+            // Relief Valve
+            'RVCleaned', 'RVRubberKit', 'RVDiscHolder', 'RVSpring', 'RVGuide', 'RVSeat', 'RVOther',
+            // Vacuum Breaker
+            'PVBCleaned', 'PVBRubberKit', 'PVBDiscHolder', 'PVBSpring', 'PVBGuide', 'PVBSeat', 'PVBOther'
+        ];
+    }
+
+    static getFinalFieldNames(): FieldName[] {
+        return [
+            'DatePassed', 'FinalTester', 'FinalTesterNo', 'FinalTestKitSerial',
+            'LinePressure', 'FinalCT1', 'FinalCT2', 'FinalRV', 'FinalAirInlet', 'Check Valve',
+            'FinalCT1Box', 'FinalCT2Box', 'BackPressure'
+        ];
+    }
+}
+
+class PDFProcessor {
+    static async clearPDF(pdfFile: File, options: PDFProcessorOptions = {}): Promise<{ blob: Blob; serialNo: string }> {
+        // Convert File to ArrayBuffer
+        const pdfBuffer = await pdfFile.arrayBuffer();
+
+        // Load the PDF document
+        const pdfDoc = await PDFDocument.load(pdfBuffer);
+        const form = pdfDoc.getForm();
+
+        const serialNoField = form.getTextField('SerialNo').getText();
+        const fields = form.getFields();
+
+        fields.forEach((field: PDFField) => {
+            if (this.shouldKeepField(field.getName(), options)) {
+                return;
+            }
+
+            this.clearField(field);
+        });
+
+        // Save the modified PDF as Uint8Array
+        const modifiedPdfBytes = await pdfDoc.save();
+
+        // Convert to Blob and return
+        return {
+            blob: new Blob([modifiedPdfBytes], {type: 'application/pdf'}),
+            serialNo: serialNoField ? serialNoField : 'UnknownSerialNo'
+        }
+    }
+
+    private static shouldKeepField(fieldName: string, options: PDFProcessorOptions): boolean {
+        return <boolean>(
+            (options.KeepInfo && PDFFieldManager.getInfoFieldNames().includes(fieldName)) ||
+            (options.KeepComments && fieldName === 'ReportComments') ||
+            (options.KeepInitialTestData && PDFFieldManager.getInitialFieldNames().includes(fieldName)) ||
+            (options.KeepRepairData && PDFFieldManager.getRepairsFieldNames().includes(fieldName)) ||
+            (options.KeepFinalTestData && PDFFieldManager.getFinalFieldNames().includes(fieldName))
+        );
+    }
+
+    private static clearField(field: PDFField): void {
+        switch (field.constructor.name) {
+            case 'PDFTextField':
+                (field as PDFTextField).setText('');
+                break;
+            case 'PDFCheckBox':
+                (field as PDFCheckBox).uncheck();
+                break;
+            case 'PDFRadioGroup':
+                (field as PDFRadioGroup).clear();
+                break;
+            case 'PDFDropdown':
+            case 'PDFOptionList':
+                (field as PDFDropdown | PDFOptionList).clear();
+                break;
+        }
+    }
+}
+
+export {PDFProcessor, PDFFieldManager, type PDFProcessorOptions};


### PR DESCRIPTION
## Changes
- Add PDF Tools section to the main dashboard with PDF editor navigation
- Implement PDF editor page with configurable clear options:
  - Generic info, comments, and test data options
  - Granular control over initial/repair/final test data
- Add PDF processing functionality:
  - Single file processing with cleared PDF download
  - Bulk processing with zip file download using JSZip
- Refactor FileUploadBox to PdfUploadBox and move to shared components
- Extract common PDF processing logic to PDFProcessor utility class

The changes add a new PDF editing feature that allows users to selectively clear PDF form fields while maintaining document structure.