### PR TITLE
fix: Handle empty serial number display in BackflowBox component

### DIFF
--- a/src/app/new/BackflowBox.tsx
+++ b/src/app/new/BackflowBox.tsx
@@ -214,7 +214,7 @@ export default function BackflowBox({
                     <ul className="space-y-2">
                         {Object.entries(backflowList).map(([id, backflow]) => (
                             <li key={id} className="flex justify-between items-center">
-                                <span>{backflow.deviceInfo.serialNo}</span>
+                                <span>{backflow.deviceInfo.serialNo == '' ? 'Unknown Serial No.' : backflow.deviceInfo.serialNo}</span>
                                 <div className="flex gap-2">
                                     <button
                                         type="button"


### PR DESCRIPTION
Why:
- Improves user experience by showing 'Unknown Serial No.' for undefined serial numbers.